### PR TITLE
Fix fake_ci scripts

### DIFF
--- a/scripts/create_branch_version.sh
+++ b/scripts/create_branch_version.sh
@@ -6,5 +6,4 @@ curl \
   -H "Authorization: Bearer ${PACT_BROKER_TOKEN}" \
   -H "Content-Type: application/json" \
   "${PACT_BROKER_BASE_URL}/pacticipants/${PACTICIPANT}/branches/${GIT_BRANCH}/versions/${GIT_COMMIT}" \
-  -d '{}
- }'
+  -d '{}'

--- a/scripts/create_version_tag.sh
+++ b/scripts/create_version_tag.sh
@@ -6,5 +6,4 @@ curl \
   -H "Authorization: Bearer ${PACT_BROKER_TOKEN}" \
   -H "Content-Type: application/json" \
   "${PACT_BROKER_BASE_URL}/pacticipants/${PACTICIPANT}/versions/${GIT_COMMIT}/tags/${GIT_BRANCH}" \
-  -d '{}
- }'
+  -d '{}'

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 
 SUCCESS=true
 if [ "${1}" != "true" ]; then
@@ -8,7 +8,7 @@ fi
 # Avoid breaking for users who don't have GNU base64 command
 # https://github.com/pactflow/example-bi-directional-provider-restassured/pull/1
 # keep base64 encoded content in one line 
-if base64 -w 0; then
+if echo | base64 -w 0 > /dev/null 2>&1; then
     echo "encoding with base64 -w 0"
     OAS=$(cat oas/swagger.yml | base64 -w 0)
 else


### PR DESCRIPTION
Hi there,

while testing the BDCT feature I was encountering some issues with the scripts that are used in the fake_ci process:

1. the JSON payload sent in the `create_branch_version.sh` and `create_version_tag.sh` scripts was not a valid JSON object
2. the attempt to check if the GNU version of `base64` is installed by calling `base64 -w 0` without any further parameters made the script halt indefinitely on Ubuntu, as the command would try to read data from standard input.

Please find attached some fixes for those issues.

Hope that helps.

Regards,
Tobias